### PR TITLE
Syntax errors, fixed root identification

### DIFF
--- a/models/depprobe.py
+++ b/models/depprobe.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 
 #
@@ -212,7 +213,8 @@ class LabelClassifier(nn.Module):
 
 	def get_labels(self, lbl_logits):
 		# gather word with highest root probability for each sentence
-		roots = torch.argmax(lbl_logits[:, :, self._root_label], dim=-1)  # (batch_size, 1)
+		lbl_logsoftmax = F.log_softmax(lbl_logits, dim=-1).nan_to_num(nan=-float('inf'))
+		roots = torch.argmax(lbl_logsoftmax[:, :, self._root_label], dim=-1)  # (batch_size, 1)
 		# set root logits to -inf to prevent multiple roots
 		lbl_logits_noroot = lbl_logits.detach().clone()
 		lbl_logits_noroot[:, :, self._root_label] = torch.ones(

--- a/train.py
+++ b/train.py
@@ -5,6 +5,7 @@ import argparse, logging, os, sys, time
 from utils.setup import *
 from utils.dataset import DepSpaceDataset
 
+from collections import defaultdict
 
 def parse_arguments():
 	arg_parser = argparse.ArgumentParser(description='Universal Dependencies - Embedding Space Parsing')

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -6,13 +6,13 @@ import transformers
 
 # local imports
 from data.ud import *
-from data.utils import *
 
 from models.embedding import *
 from models.probing import *
 from models.depprobe import *
 from models.loss import *
 
+from collections import defaultdict
 
 def setup_output_directory(out_path):
 	if os.path.exists(out_path):
@@ -167,7 +167,7 @@ def setup_criterion(parser_type='depprobe'):
 			f"Using {criterion.__class__.__name__} with "
 			f"{criterion._depth_loss.__class__.__name__} and {criterion._distance_loss.__class__.__name__}.")
 	# use depprobe loss
-	else parser_type.startswith('depprobe'):
+	elif parser_type.startswith('depprobe'):
 		criterion = RootedDependencyLoss()
 		logging.info(
 			f"Using {criterion.__class__.__name__} with "


### PR DESCRIPTION
This pull request has two components. 
- First, the codebase has some minor syntax and import errors, without which the code does not run. 
- Second, the ACL paper describes that dependency tree roots are identified by finding the word at which p(root) is highest across the sentence. However, the current code identifies the root by taking the word at which the logit for root is highest. Leads to slightly different results on some masked models, In some autoregressive models, logits at the sentence start are really high, and then the first words are selected as the root. 